### PR TITLE
Fix exception handling

### DIFF
--- a/functions/session.js
+++ b/functions/session.js
@@ -33,7 +33,7 @@ function createSession() {
   return new Promise((resolve, reject) => {
     OT.createSession((err, session) => {
       if (err) reject(err)
-      resolve(session.sessionId)
+      else resolve(session.sessionId)
     })
   })
 }

--- a/functions/session.js
+++ b/functions/session.js
@@ -32,8 +32,8 @@ exports.handler = async event => {
 function createSession() {
   return new Promise((resolve, reject) => {
     OT.createSession((err, session) => {
-      if (err) reject(err)
-      else resolve(session.sessionId)
+      if (err) return reject(err)
+      resolve(session.sessionId)
     })
   })
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] You've followed the [contributing guidelines](CONTRIBUTING.md)
- [x] You've adheared the [code of conduct](CODE_OF_CONDUCT.md)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- [x] Bug Fix

## If bug fixes or new features

* **What is the current behavior?** (You can also link to an open issue here)

Found your repo via `hacktoberfest` and while poking around I wasn't sure why the setup wasn't working. After digging around, I realized that I put in the wrong `VIDEO_KEY` and `VIDEO_SECRET` (same as https://github.com/opentok/opentok-node/issues/208).

This exception wasn't helpful:
```
/usr/local/lib/node_modules/netlify-cli/node_modules/netlify-redirector/lib/redirects.js:116
      throw ex;
      ^

TypeError: Cannot read property 'sessionId' of undefined
    at OT.createSession (/home/shinn/git/build-a-thing-video/functions/session.js:37:27)
    at createSessionCallback (/home/shinn/git/build-a-thing-video/node_modules/opentok/lib/opentok.js:1129:7)
    at Request._callback (/home/shinn/git/build-a-thing-video/node_modules/opentok/lib/client.js:64:14)
    at Request.self.callback (/home/shinn/git/build-a-thing-video/node_modules/request/request.js:185:22)
    at Request.emit (events.js:198:13)
    at Request.<anonymous> (/home/shinn/git/build-a-thing-video/node_modules/request/request.js:1154:10)
    at Request.emit (events.js:198:13)
    at IncomingMessage.<anonymous> (/home/shinn/git/build-a-thing-video/node_modules/request/request.js:1076:12)
    at Object.onceWrapper (events.js:286:20)
    at IncomingMessage.emit (events.js:203:15)
```
* **What is the new behavior (if this is a feature change)?**

Properly handle and not swallow the exception:
```
Error: Failed to createSession. Error: An authentication error occurred: (403) {"code":-1,"message":"Invalid signature","description":"Invalid signature"}
Response with status 500 in 479 ms.
```

